### PR TITLE
Fix aria label

### DIFF
--- a/src/profilo.php
+++ b/src/profilo.php
@@ -161,11 +161,11 @@ if(isset($_SESSION['username'])){
 
                 if($row['isAdmin']){
                     $caricaNFT = file_get_contents('./static/carica-nft.html');
-                    $skipButton.='<nav aria-label="aiuti alla navigazione" class="listHelp">
+                    $skipButton.='<nav aria-label="aiuti alla navigazione: aggiungi NFT" class="listHelp">
 	<a href="#agg-nft" class="navigationHelp">Vai ad Aggiungi <abbr lang="en" title="Non-fungible token">NFT</abbr></a>
       </nav>';
                 }else{
-                    $skipButton.='<nav aria-label="aiuti alla navigazione" class="listHelp">
+                    $skipButton.='<nav aria-label="aiuti alla navigazione: miei NFT" class="listHelp">
 	<a href="#miei-nft" class="navigationHelp">Vai ai Miei <abbr lang="en" title="Non-fungible token">NFT</abbr></a>
       </nav>';
                 }

--- a/src/singolo-nft.php
+++ b/src/singolo-nft.php
@@ -52,7 +52,7 @@ function getRecensioni($recensioni, $pageNumber, $pageSize) {
 }
 
 function mostraAggiungiRecensione(&$aggiungi_recensione_html, $id) {
-    $aggiungi_recensione_html.='<nav aria-label="aiuti alla navigazione" class="listHelp">
+    $aggiungi_recensione_html.='<nav aria-label="aiuti alla navigazione: recensioni" class="listHelp">
 	<a href="#recensioni" class="navigationHelp">Vai alle recensioni</a>
       </nav>';
     $aggiungi_recensione_html.='<form id="agg-recensione" class="user-form" action="singolo-nft.php" method="post">';
@@ -180,7 +180,7 @@ if (!$connessioneOK) {
             #se l'utente è loggato vede il bottone acquista
             if(isset($_SESSION['username'])){
                 if(strcmp($_SESSION['username'],'admin')!=0){
-                    $opera_html.='<nav aria-label="aiuti alla navigazione" class="listHelp">
+                    $opera_html.='<nav aria-label="aiuti alla navigazione: aggiungi recensioni" class="listHelp">
 	<a href="#recensione" class="navigationHelp">Vai ad aggiungi recensioni</a>
       </nav>';
                     $opera_html.='<form id="acq-nft" action="singolo-nft.php" method="post">';

--- a/src/static/404.html
+++ b/src/static/404.html
@@ -22,7 +22,7 @@
       <!-- Script js -->
       <script src="script.js"></script>
 
-    <nav aria-label="aiuti alla navigazione" class="listHelp">
+    <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
       <a href="#content" class="navigationHelp">Vai al contenuto</a>
      </nav>
     <nav class="header-content">

--- a/src/static/500.html
+++ b/src/static/500.html
@@ -22,7 +22,7 @@
       <!-- Script js -->
       <script src="script.js"></script>
 
-    <nav aria-label="aiuti alla navigazione" class="listHelp">
+    <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
       <a href="#content" class="navigationHelp">Vai al contenuto</a>
      </nav>
     <nav class="header-content">

--- a/src/static/accedi.html
+++ b/src/static/accedi.html
@@ -22,7 +22,7 @@
   <body>
 
     <header>
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
         <a href="#content" class="navigationHelp">Vai al contenuto</a>
       </nav>
       <nav class="header-content">

--- a/src/static/carica-nft.html
+++ b/src/static/carica-nft.html
@@ -1,4 +1,4 @@
-<nav id='agg-nft' aria-label="aiuti alla navigazione" class="listHelp">
+<nav id='agg-nft' aria-label="aiuti alla navigazione: miei NFT" class="listHelp">
   <a href="#miei-nft" class="navigationHelp">Vai ai Miei <abbr lang="en" title="Non-fungible token">NFT</abbr></a>
 </nav>
 <form id='add-nft' class='user-form' action='profilo.php' method='post' onsubmit="return validazioneCaricaNft();" enctype='multipart/form-data'>

--- a/src/static/chi-siamo.html
+++ b/src/static/chi-siamo.html
@@ -20,7 +20,7 @@
 
     <body>
         <header>
-            <nav aria-label="aiuti alla navigazione" class="listHelp">
+            <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
                 <a href="#content" class="navigationHelp">Vai al contenuto</a>
             </nav>
             <nav class="header-content">
@@ -37,7 +37,7 @@
         
         <main id="content">
             <h1><span lang="en">Chi Siamo</span></h1>
-	    <nav aria-label="aiuti alla navigazione" class="listHelp">
+	    <nav aria-label="aiuti alla navigazione: F.A.Q" class="listHelp">
 	      <a href="#faq" class="navigationHelp">Vai alle <abbr lang="en" title="Frequently Asked Questions">F.A.Q.</abbr></a>
 	    </nav>
             <p>Siamo un team appassionato di tecnologia, arte digitale e innovazione. La nostra missione è creare uno spazio in cui creatori e collezionisti possano connettersi, scoprire opere uniche e valorizzare il mondo degli <abbr title="Non-Fungible Token">NFT</abbr>. Crediamo nel potere della <span lang="en">blockchain</span> per rivoluzionare il modo in cui l'arte e la proprietà digitale vengono vissute. Unisciti a noi in questo viaggio nel futuro del digitale! </p>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -23,7 +23,7 @@
       <!-- Script js -->
       <script src="script.js"></script>
 
-    <nav aria-label="aiuti alla navigazione" class="listHelp">
+    <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
       <a href="#content" class="navigationHelp">Vai al contenuto</a>
      </nav>
     <nav class="header-content">
@@ -40,12 +40,12 @@
 
     <main id="content">
       <h1><span lang="en">Home</span></h1>
-	<nav aria-label="aiuti alla navigazione" class="listHelp">
+	<nav aria-label="aiuti alla navigazione: ultime uscite" class="listHelp">
 	    <a href="#ultimeUscite" class="navigationHelp">Vai alle Ultime Uscite</a>
 	</nav>
 	<p>DoFlamingo è un sito innovativo per scoprire, acquistare e vendere <abbr lang="en" title="Non-fungible token">NFT</abbr>, con un'ampia selezione di opere digitali uniche e collezionabili. In questa pagina troverai le ultime opere uscite, la classifica delle 3 opere votate più positivamente e le categorie di opere con maggiori acquisti.</p>
       <h2 id="ultimeUscite">Ultime uscite</h2>
-    <nav aria-label="aiuti alla navigazione" class="listHelp">
+    <nav aria-label="aiuti alla navigazione: top 3" class="listHelp">
       <a href="#top3" class="navigationHelp">Vai alla <span lang="en">Top</span> 3</a>
      </nav>
     <div class="last-cards">
@@ -54,7 +54,7 @@
     <p class="center"><a href="nft.php">Visualizza gli altri <abbr lang="en" title="Non-fungible token">NFT</abbr></a></p>
       
       <h2 id="top3"><span lang="en">Top</span> 3 <abbr lang="en" title="Non-fungible token">NFT</abbr></h2>
-    <nav aria-label="aiuti alla navigazione" class="listHelp">
+    <nav aria-label="aiuti alla navigazione: categorie più acquistate" class="listHelp">
       <a href="#acquistate" class="navigationHelp">Vai alle Categorie più acquistate</a>
      </nav>
 	<div id="cards">

--- a/src/static/logout.html
+++ b/src/static/logout.html
@@ -19,7 +19,7 @@
   </head>
   <body>
     <header>
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
         <a href="#content" class="navigationHelp">Vai al contenuto</a>
       </nav>
       <nav class="header-content">

--- a/src/static/mie-recensioni.html
+++ b/src/static/mie-recensioni.html
@@ -22,7 +22,7 @@
   <body>
 
     <header>
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
         <a href="#content" class="navigationHelp">Vai al contenuto</a>
       </nav>
       <nav class="header-content">
@@ -42,7 +42,7 @@
 
       <h1>Mie recensioni</h1>
 
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: recensioni" class="listHelp">
 	<a href="#recensioni" class="navigationHelp">Vai alle recensioni</a>
       </nav>
 

--- a/src/static/miei-nft.html
+++ b/src/static/miei-nft.html
@@ -22,7 +22,7 @@
   <body>
 
     <header>
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
         <a href="#content" class="navigationHelp">Vai al contenuto</a>
       </nav>
       <nav class="header-content">
@@ -42,7 +42,7 @@
 
       <h1>Miei <abbr lang="en" title="Non-fungible token">NFT</abbr></h1>
 
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: NFT" class="listHelp">
 	<a href="#cards" class="navigationHelp">Vai agli <abbr lang="en" title="Non-fungible token">NFT</abbr></a>
       </nav>
 

--- a/src/static/modifica-recensione.html
+++ b/src/static/modifica-recensione.html
@@ -19,7 +19,7 @@
   </head>
   <body>
     <header>
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
         <a href="#content" class="navigationHelp">Vai al contenuto</a>
       </nav>
       <nav class="header-content">

--- a/src/static/nft.html
+++ b/src/static/nft.html
@@ -23,7 +23,7 @@
   <body>
 
     <header>
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
         <a href="#content" class="navigationHelp">Vai al contenuto</a>
       </nav>
       <nav class="header-content">
@@ -43,7 +43,7 @@
 
       <h1>Cerca <abbr lang="en" title="Non-fungible token">NFT</abbr></h1>
 
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: NFT" class="listHelp">
 	<a href="#cards" class="navigationHelp">Vai agli <abbr lang="en" title="Non-fungible token">NFT</abbr></a>
       </nav>
 

--- a/src/static/profilo.html
+++ b/src/static/profilo.html
@@ -22,7 +22,7 @@
   <body>
     <header>
 
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
         <a href="#content" class="navigationHelp">Vai al contenuto</a>
       </nav>
       <nav class="header-content">
@@ -63,7 +63,7 @@
 
       <h2 id="miei-nft">I miei <abbr lang="en" title="Non-fungible token">NFT</abbr></h2>
 
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: mie recensioni" class="listHelp">
 	<a href="#mie-recensioni" class="navigationHelp">Vai alle Mie recensioni</a>
       </nav>
 

--- a/src/static/registrati.html
+++ b/src/static/registrati.html
@@ -22,7 +22,7 @@
   <body>
 
     <header>
-      <nav aria-label="aiuti alla navigazione" class="listHelp">
+      <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
         <a href="#content" class="navigationHelp">Vai al contenuto</a>
       </nav>
       <nav class="header-content">

--- a/src/static/singolo-nft.html
+++ b/src/static/singolo-nft.html
@@ -23,7 +23,7 @@
       <!-- Script js -->
       <script src="script.js"></script>
 
-    <nav aria-label="aiuti alla navigazione" class="listHelp">
+    <nav aria-label="aiuti alla navigazione: contenuto" class="listHelp">
       <a href="#content" class="navigationHelp">Vai al contenuto</a>
      </nav>
     <nav class="header-content">


### PR DESCRIPTION
Ricontrollando con Total Validator i warning sono scomparsi.
Ho distinto le label concatenando la stringa della destinazione (ho cambiato solo nelle pagine con più di un aria-label).

close #149 