### PR TITLE
cambiato nella top 3 NFT il simbolo di grado (°)

### DIFF
--- a/src/php/CardOpera.php
+++ b/src/php/CardOpera.php
@@ -31,7 +31,7 @@ class CardOpera {
         $homeTopCard = str_replace('{{CARD_ID}}', "id={$idTopPosition}", $homeTopCard);
         $homeTopCard = str_replace('{{CARD_HEADER}}', $this->getCardHeader(), $homeTopCard);
 
-        $spanPosition = "<span>{$topPosition}°</span>";
+        $spanPosition = "<span>{$topPosition}º</span>";
         return str_replace('{{HEADER}}', $spanPosition . $this->getCardNameHeading("h3"), $homeTopCard);
     }
 


### PR DESCRIPTION
da simbolo grado (°) a indicatore ordinale maschile (º) per far leggere nel modo corretto allo screen reader (un grado (1°) -> primo (1º))